### PR TITLE
feat: Upgrade Quarkus to 3.8.3 in menu-service

### DIFF
--- a/menu-service/pom.xml
+++ b/menu-service/pom.xml
@@ -16,7 +16,6 @@
     <quarkus.platform.version>3.8.3</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <quarkus.version>1.0.0.CR1</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This pull request refactors the menu-service to use Quarkus 3.8.3. This addresses the technical debt of using an outdated Quarkus version. The Jira task for this is GENDEV-18.